### PR TITLE
Fix missing deps

### DIFF
--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -51,6 +51,9 @@ func depsCmdRun(cmd *cobra.Command, args []string) error {
 		{"github.com/spf13/viper"},
 		{"github.com/markbates/refresh"},
 		{"gopkg.in/nullbio/null.v6"},
+		{"github.com/djherbis/times"},
+		{"github.com/satori/go.uuid"},
+		{"gopkg.in/redis.v5"},
 		{"-t", "github.com/vattle/sqlboiler"},
 	}
 


### PR DESCRIPTION
While following the the readme I got the error on my genrated apps:

```
refresh: 2017/06/16 22:19:42 === Running: go build -v -i -o /tmp/try_abcwebbuild (PID: 30501) ===
../../github.com/volatiletech/abcweb/abcsessions/disk.go:10:2: cannot find package "github.com/djherbis/times" in any of:
	/usr/local/go/src/github.com/djherbis/times (from $GOROOT)
	/home/yml/gopath/src/github.com/djherbis/times (from $GOPATH)
../../github.com/volatiletech/abcweb/abcsessions/storage_overseer.go:7:2: cannot find package "github.com/satori/go.uuid" in any of:
	/usr/local/go/src/github.com/satori/go.uuid (from $GOROOT)
	/home/yml/gopath/src/github.com/satori/go.uuid (from $GOPATH)
../../github.com/volatiletech/abcweb/abcsessions/redis.go:7:2: cannot find package "gopkg.in/redis.v5" in any of:
	/usr/local/go/src/gopkg.in/redis.v5 (from $GOROOT)
	/home/yml/gopath/src/gopkg.in/redis.v5 (from $GOPATH)
```
Thank you for sharing this bundle of fine tech.
