### PR TITLE
Add github.com/golang/deps command to deps.go

### DIFF
--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -55,6 +55,7 @@ func depsCmdRun(cmd *cobra.Command, args []string) error {
 		{"github.com/satori/go.uuid"},
 		{"gopkg.in/redis.v5"},
 		{"-t", "github.com/vattle/sqlboiler"},
+		{"github.com/golang/dep/cmd/dep"},
 	}
 
 	npmInstallArgs := [][]string{


### PR DESCRIPTION
README says "abcweb deps -u" but it doesn't fetch golang/deps and running "abcweb new" without deps throws the following error.

Error: could not find "dep" dependency in $PATH. Please run "abcweb deps" to install all missing dependencies.

Just updating the file to add golang/deps